### PR TITLE
Move to python 3.9 due to scipy issues 

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,8 @@ cut_data_method: "voronoi_tessellation" #рекомендуется
 
 1. **Установка**:
     ```bash
-    conda create --name pcPCDenv379 python==3.7.9
-    conda activate pcPCDenv379
+    conda create --name pcPCDenv39 python==3.9.16
+    conda activate pcPCDenv39
     pip install git+https://github.com/iu5git/LiDARSegmentation/
     ```
     По умолчанию, `torch` при установке должен определить конфигурацию и самостоятельно выбрать наиболее подходящий `wheel`. В случае проблем с авто-определением, установите его отдельно и повторите установку библиотеки:

--- a/lidarsegmentation/coordinates.py
+++ b/lidarsegmentation/coordinates.py
@@ -17,6 +17,7 @@ def coordinates(intensity_cut_make, cs):
     # Return dict: map of stump name to PCD objects
     pcd_map = {}
     
+    file_name_traj, file_name_data, file_shape = None, None, None
     if cs.fname_traj is not None and cs.fname_traj != '':
         file_name_traj = os.path.join(cs.path_base, cs.fname_traj)
     if cs.fname_points is not None and cs.fname_points != '':
@@ -25,8 +26,7 @@ def coordinates(intensity_cut_make, cs):
         file_shape = os.path.join(cs.path_base, cs.fname_shape)
 
     # Keep track of PC data in memory instead of saving to file
-    pc_area = None
-    pc_traj = None
+    pc_area, pc_traj = None, None
     
     if cs.cut_data_method == 'flood_fill' and (cs.FLAG_cut_data or cs.FLAG_make_cells):
         pc_traj = PCD()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "lidarsegmentation"
 version = "0.1.0"
 description = "Locating Trees and Individual Tree Segmentation Using Deep Learning Models LiDAR Based"
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Operating System :: OS Independent",
@@ -103,7 +103,7 @@ dependencies = [
     "pyzmq>=25.0.2",
     "requests>=2.28.2",
     "scikit-learn>=1.0.2",
-    "scipy>=1.7.3",
+    "scipy>=1.9.3",
     "scooby>=0.7.1",
     "seaborn>=0.12.2",
     "shapely>=2.0.1",


### PR DESCRIPTION
 `scipy,sparse.coo_array` was only introduced in 1.8.0, but sklearn still depends on it while not providing a wheel for Python 3.7. No idea how it worked before, to be honest.. 
To mitigate this dependency hell, this PR updates minimum Python version to a slightly more modern Python 3.9 